### PR TITLE
Update jsx-space-before-closing rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ module.exports = {
     "react/jsx-no-undef": 2,
     "react/jsx-pascal-case": [2],
     // "react/jsx-sort-props": 0,
-    "react/jsx-space-before-closing": 2,
+    "react/jsx-tag-spacing": [2, "beforeSelfClosing"],
     "react/jsx-uses-react": 2,
     "react/jsx-uses-vars": 2
   },


### PR DESCRIPTION
The new release of the `eslint-plugin-react` package deprecates the usage of the `jsx-space-before-closing` rule and asks to update to the `jsx-tag-spacing` rule with the `beforeSelfClosing` option.

Here's the link to the update: https://github.com/yannickcr/eslint-plugin-react/releases/tag/v7.0.0