### PR TITLE
react/jsx-tag-spacing not working

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ module.exports = {
     "react/jsx-no-undef": 2,
     "react/jsx-pascal-case": [2],
     // "react/jsx-sort-props": 0,
-    "react/jsx-tag-spacing": [2, "beforeSelfClosing"],
+    "react/jsx-tag-spacing": 2,
     "react/jsx-uses-react": 2,
     "react/jsx-uses-vars": 2
   },


### PR DESCRIPTION
When I installed eslint-config-vtex-react in a new repo, ```./node_modules/.bin/eslint src``` crashes saying:

```
eslint-config-vtex-react:
	Configuration for rule "react/jsx-tag-spacing" is invalid:
	Value "beforeSelfClosing" is the wrong type.
```

@tamorim ```beforeSelfClosing: "always"``` is a default value: https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-tag-spacing.md#rule-details

I think this rule should be only: ```"react/jsx-tag-spacing": 2,``` so it can work on new repos again.